### PR TITLE
Feat/allow gh protection null

### DIFF
--- a/src/Deploy-GitHubRepository.ps1
+++ b/src/Deploy-GitHubRepository.ps1
@@ -704,10 +704,10 @@ if (!$lzConfig.decommissioned) {
         #endregion
 
         ##################################
-        ###* Create environment branch policy patterns
+        ###* Set environment branch policy patterns
         ##################################
         #region
-        Write-Host "Create environment branch policy patterns: $($environmentName)"
+        Write-Host "Set environment branch policy patterns: $($environmentName)"
 
         #* Determine configuration source
         $config = $null

--- a/src/Deploy-GitHubRepository.ps1
+++ b/src/Deploy-GitHubRepository.ps1
@@ -588,7 +588,7 @@ if (!$lzConfig.decommissioned) {
         }
     }
     elseif ($null -ne $config) {
-        Write-Host "- CODEOWNERS file is: $($config | ConvertTo-Json -Depth 10)"
+        Write-Host "- CODEOWNERS file is: `"$($config | ConvertTo-Json -Depth 10)`""
         $body = @{}
         $update = $true
     

--- a/src/Deploy-GitHubRepository.ps1
+++ b/src/Deploy-GitHubRepository.ps1
@@ -666,6 +666,13 @@ if (!$lzConfig.decommissioned) {
             Write-Host "  - Skipping. Run protection property not set or set to 'null' in both Landing Zone configuration file and climprconfig file."
         }
 
+        #* Check if environment exists
+        $currentEnvironment = Invoke-GitHubCliApiMethod -Method "GET" -Uri "/repos/$org/$repo/environments/$environmentName" -ErrorAction Ignore 2>$null
+        if (!$currentEnvironment -and ($null -eq $config -or $config -eq "ignore")) {
+            $config = "default"
+            Write-Host "  - Environment not found. Creating environment once with default settings."
+        }
+        
         #* Calculate configuration
         $configure = $false
         switch ($config) {

--- a/src/Deploy-GitHubRepository.ps1
+++ b/src/Deploy-GitHubRepository.ps1
@@ -623,7 +623,7 @@ if (!$lzConfig.decommissioned) {
         $branchPolicyPatterns = Join-Arrays -Array1 $branchPolicyPatterns -Array2 $environment.branchPolicyPatterns
 
         #* Remove patterns not present in Landing Zone config file
-        $currentPatterns = Invoke-GitHubCliApiMethod -Method "GET" -Uri "/repos/$org/$repo/environments/$environmentName/deployment-branch-policies"
+        $currentPatterns = Invoke-GitHubCliApiMethod -Method "GET" -Uri "/repos/$org/$repo/environments/$environmentName/deployment-branch-policies" -ErrorAction Ignore 2>$null
         foreach ($pattern in $currentPatterns.branch_policies) {
             $shallExists = $branchPolicyPatterns | Where-Object { $_.name -eq $pattern.name -and $_.type -eq $pattern.type }
             if (!$shallExists) {


### PR DESCRIPTION
This PR is non-breaking and allows the use of `ignore`, `default` or desired settings for GitHub repository configuration. 

Settings not set in the climprconfig.json file will be ignored by default. Since the settings were mandatory before this change, it is non-breaking.

Must be seen together with schema update: https://github.com/climpr/climpr-schemas/pull/7