### PR TITLE
refactor: Remove MSGraph login from Deploy-GitHubRepository.ps1

### DIFF
--- a/src/Deploy-GitHubRepository.ps1
+++ b/src/Deploy-GitHubRepository.ps1
@@ -42,11 +42,6 @@ $defaultRepositoryConfig = $climprConfig.lzManagement.gitWorkloadRepository
 #* Parse Landing Zone configuration file
 $lzConfig = Get-Content -Path $lzFile.FullName -Encoding utf8 | ConvertFrom-Json -AsHashtable -Depth 10
 
-#* MSGraph login
-$token = Get-AzAccessToken -ResourceUrl "https://graph.microsoft.com"
-$secureAccessToken = $token.Token | ConvertTo-SecureString -AsPlainText -Force
-Connect-MgGraph -AccessToken $secureAccessToken | Out-Null
-
 #* Declare git variables
 $org = $lzConfig.organization
 $repo = $lzConfig.repoName


### PR DESCRIPTION
This pull request removed the MSGraph login process in the `src/Deploy-GitHubRepository.ps1` script. This authentication logic was unnecessary since there is no requests to MSGraph.
