### PR TITLE
fix: environment deployment branch policy patterns handling

### DIFF
--- a/src/Deploy-GitHubRepository.ps1
+++ b/src/Deploy-GitHubRepository.ps1
@@ -741,11 +741,12 @@ if (!$lzConfig.decommissioned) {
             }
             "default" {
                 Write-Host "- Branch policy patterns property is 'default'. Default settings for GitHub is to not implement any branch policy patterns."
-                $config = @()
+                $branchPolicyPatterns = @()
                 $configure = $true
             }
             default {
-                Write-Host "- Branch policy patterns property is: $($config | ConvertTo-Json -Depth 10)"
+                Write-Host "- Branch policy patterns property is: $($environment.branchPolicyPatterns | ConvertTo-Json -Depth 10)"
+                $branchPolicyPatterns = $environment.branchPolicyPatterns
                 $configure = $true
             }
         }


### PR DESCRIPTION
This pull request fixes the logic for handling branch policy patterns in the `src/Deploy-GitHubRepository.ps1` script. The change correctly ensures the variable `$branchPolicyPatterns` is assigned a value before the script loops over it when configuring branch policy patterns.

Currently `$branchPolicyPatterns` is never assigned a value, so no pattern is allowed to exist and no new is ever created/updated.