### PR TITLE
Feat/make OIDC claims configurable

### DIFF
--- a/src/Deploy-GitHubRepository.ps1
+++ b/src/Deploy-GitHubRepository.ps1
@@ -469,16 +469,18 @@ if (!$lzConfig.decommissioned) {
     ###* MARK: Set OIDC Hardening
     ##################################
     #region
-    Write-Host "Set OIDC Hardening"
+    $includedClaims = $climprConfig.lzManagement.oidcClaimKeys ?  $climprConfig.lzManagement.oidcClaimKeys : @(
+        "repo"
+        "context"
+        "ref"
+        "workflow"
+    )
+    
+    Write-Host "Set OIDC Hardening with included claims: $($includedClaims | ConvertTo-Json)"
 
     $body = @{
         use_default        = $false
-        include_claim_keys = $climprConfig.lzManagement.oidcClaimKeys ?  $climprConfig.lzManagement.oidcClaimKeys : @(
-            "repo"
-            "context"
-            "ref"
-            "workflow"
-        )
+        include_claim_keys = $includedClaims
     }
 
     try {

--- a/src/Deploy-GitHubRepository.ps1
+++ b/src/Deploy-GitHubRepository.ps1
@@ -473,7 +473,7 @@ if (!$lzConfig.decommissioned) {
 
     $body = @{
         use_default        = $false
-        include_claim_keys = @(
+        include_claim_keys = $climprConfig.lzManagement.oidcClaimKeys ?  $climprConfig.lzManagement.oidcClaimKeys : @(
             "repo"
             "context"
             "ref"


### PR DESCRIPTION
This pull request updates the OIDC hardening configuration logic in the `src/Deploy-GitHubRepository.ps1` script. The change ensures that the included claim keys for OIDC are sourced from the configuration if available, and otherwise defaults to a predefined set. It also improves logging for better traceability.

OIDC Hardening improvements:

* Updated the assignment of `include_claim_keys` to use `$climprConfig.lzManagement.oidcClaimKeys` if present, otherwise defaulting to a standard set of claims.
* Enhanced logging to output the actual included claims being set for OIDC hardening.